### PR TITLE
feat(form.js): Add click_workflow_button helper

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -207,6 +207,10 @@ export default {
 	async click_form_menu() {
 		await this.click_element('.btn-default', 'Menu');
 	},
+	
+	async click_workflow_button(text) {
+		await this.click_element('.btn-primary', text);
+	},
 
 	async click_toolbar_button(text) {
 		let button_text, dropdown_item;


### PR DESCRIPTION
Usage
```
    await f.click_workflow_button("Actions")

```
Closes https://github.com/frappe/video/issues/20